### PR TITLE
fix property null value encoding

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -277,7 +277,10 @@ impl Encoder {
                 data_value.set_json_value(value.to_string());
                 values.push(data_value);
             }
-            JSONValue::Null => {}
+            JSONValue::Null => {
+                data_value.set_json_value(value.to_string());
+                values.push(data_value);
+            }
         };
         properties.push(values.len() as u32 - 1);
     }


### PR DESCRIPTION
Hello,

noticed that with some of my Features that had a property containing null, the encode function was panicking at line 282, after applying this fix things work fine, decode then produces correct null value for the property.